### PR TITLE
[Typo correction] Move right node traversal within the for loop

### DIFF
--- a/✅  Pattern 07: Tree Breadth First Search.md
+++ b/✅  Pattern 07: Tree Breadth First Search.md
@@ -85,9 +85,9 @@ function traverse (root) {
       if(TreeNode.left !== null) {
         queue.addBack(TreeNode.left)
       }
-    }
-    if(TreeNode.right !== null) {
-      queue.addBack(TreeNode.right)
+      if(TreeNode.right !== null) {
+        queue.addBack(TreeNode.right)
+      }
     }
   }
   


### PR DESCRIPTION
Correcting a typo
The right node should be traversed within the for loop.
